### PR TITLE
Fixed initialization of $catcontent variable in course_renderer.php

### DIFF
--- a/classes/output/core/course_renderer.php
+++ b/classes/output/core/course_renderer.php
@@ -111,7 +111,8 @@ if ($PAGE->theme->settings->coursetilestyle < 10) {
                             $pixcontent .= html_writer::end_tag('div'); // .enrolmenticons
                         }
                         // display course category if necessary (for example in search results)
-                        require_once($CFG->libdir. '/coursecatlib.php');
+			require_once($CFG->libdir. '/coursecatlib.php');
+			$catcontent = '';
                         if ($cat = coursecat::get($course->category, IGNORE_MISSING)) {
                             $catcontent = html_writer::start_tag('div', array('class' => 'coursecat'));
                             $catcontent .= get_string('category').': '.
@@ -610,7 +611,8 @@ if ($PAGE->theme->settings->coursetilestyle < 10) {
                             $pixcontent .= html_writer::end_tag('div'); // .enrolmenticons
                         }
                         // display course category if necessary (for example in search results)
-                        require_once($CFG->libdir. '/coursecatlib.php');
+			require_once($CFG->libdir. '/coursecatlib.php');
+			$catcontent = '';
                         if ($cat = coursecat::get($course->category, IGNORE_MISSING)) {
                             $catcontent = html_writer::start_tag('div', array('class' => 'coursecat'));
                             $catcontent .= get_string('category').': '.


### PR DESCRIPTION
Variable $catcontent is not initialized in loops. Courses whose
category is hidden receive the category info of the previous course in
loop.

Now hidden course categories are not shown in course summary on the frontpage.