### PR TITLE
Fixed collapsibletopics section-id bug

### DIFF
--- a/classes/format_collapsibletopics_renderer.php
+++ b/classes/format_collapsibletopics_renderer.php
@@ -296,7 +296,7 @@ if (file_exists($CFG->dirroot . '/course/format/collapsibletopics/renderer.php')
 
 	        }
             $o .= '<div>' . $activities . '</div> ';
-            $o .= $courserenderer->course_section_add_cm_control($course, 0, 0);
+            $o .= $courserenderer->course_section_add_cm_control($course, $section->section, 0);
             $o .= html_writer::end_tag('div');
             
 


### PR DESCRIPTION
Good evening,

this is just a one-line-bugfix for a problem with the collapsibletopics course format:
By a little type, all the section ids for the "Add activity" buttons have been set to 0. Since all the forms to add activities now had the same id, it was impossible to use the buttons (no "jump" post variable was set, hence an error occurred).
By this fix, they now get the right ids (from 0 to n).

Kind regards from Germany
Yorick

<img width="1555" alt="1" src="https://user-images.githubusercontent.com/39629166/66493833-05478a00-eab7-11e9-834c-500779debb82.png">
<img width="1555" alt="2" src="https://user-images.githubusercontent.com/39629166/66493835-05478a00-eab7-11e9-92e6-1e39059d1a40.png">
<img width="1555" alt="3" src="https://user-images.githubusercontent.com/39629166/66493832-04aef380-eab7-11e9-8974-d95f71a86099.png">