### PR TITLE
Add Content bank into teacher dashboard

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -1247,6 +1247,8 @@ class core_renderer extends \theme_boost\output\core_renderer {
         $userlinksdesc = get_string('userlinks_desc', 'theme_fordson');
         $qbank = get_string('qbank', 'theme_fordson');
         $qbankdesc = get_string('qbank_desc', 'theme_fordson');
+        $cbank = get_string('cbank', 'theme_fordson');
+        $cbankdesc = get_string('cbank_desc', 'theme_fordson');
         $badges = get_string('badges', 'theme_fordson');
         $badgesdesc = get_string('badges_desc', 'theme_fordson');
         $coursemanage = get_string('coursemanage', 'theme_fordson');
@@ -1328,6 +1330,11 @@ class core_renderer extends \theme_boost\output\core_renderer {
         $qexporttitle = get_string('export', 'question');
         $qexportlink = new moodle_url('/question/export.php', array(
             'courseid' => $PAGE->course->id
+        ));
+        // Content Bank.
+        $cbankaddtitle = get_string('contentbank', 'moodle');
+        $cbankaddlink = new moodle_url('/contentbank/index.php', array(
+            'contextid' => $context->id
         ));
         // Manage course.
         $courseadmintitle = get_string('courseadministration', 'moodle');
@@ -1516,6 +1523,7 @@ class core_renderer extends \theme_boost\output\core_renderer {
         $studentcoursemanage = get_string('courseadministration', 'moodle');
         // Permissionchecks for teacher access.
         $hasquestionpermission = has_capability('moodle/question:add', $context);
+        $hascontentbankpermission = has_capability('contenttype/h5p:access', $context);
         $hasbadgepermission = has_capability('moodle/badges:awardbadge', $context);
         $hascoursepermission = has_capability('moodle/backup:backupcourse', $context);
         $hasuserpermission = has_capability('moodle/course:viewhiddenactivities', $context);
@@ -1537,7 +1545,9 @@ class core_renderer extends \theme_boost\output\core_renderer {
             'qbanktitle' => $qbank, 
             'activitylinkstitle' => $activitylinkstitle, 
             'activitylinkstitle_desc' => $activitylinkstitle_desc, 
-            'qbankdesc' => $qbankdesc, 
+            'qbankdesc' => $qbankdesc,
+            'cbanktitle' => $cbank,
+            'cbankdesc' => $cbankdesc, 
             'badgestitle' => $badges, 
             'badgesdesc' => $badgesdesc, 
             'coursemanagetitle' => $coursemanage, 
@@ -1558,6 +1568,7 @@ class core_renderer extends \theme_boost\output\core_renderer {
             'editcog'=> $editcog, 
             'teacherdash' => array(
                 'hasquestionpermission' => $hasquestionpermission,
+                'hascontentbankpermission' => $hascontentbankpermission,
                 'hasbadgepermission' => $hasbadgepermission,
                 'hascoursepermission' => $hascoursepermission,
                 'hasuserpermission' => $hasuserpermission
@@ -1716,6 +1727,11 @@ class core_renderer extends \theme_boost\output\core_renderer {
                     'hasbadgelinks' => $badgeaddtitle,
                     'title' => $badgeaddtitle,
                     'url' => $badgeaddlink
+                ) ,
+                array(
+                    'hascbanklinks' => $cbankaddtitle,
+                    'title' => $cbankaddtitle,
+                    'url' => $cbankaddlink
                 ) ,
             ) ,
             ];

--- a/lang/en/theme_fordson.php
+++ b/lang/en/theme_fordson.php
@@ -287,6 +287,8 @@ $string['navbarcolorswitch_off'] = 'Do not change navbar color based on role.';
 //teacher and student dashboard slider
 $string['userlinks'] = 'User Links';
 $string['userlinks_desc'] = 'Manage your students';
+$string['cbank'] = 'Content Bank';
+$string['cbank_desc'] = 'Manage interactive content';
 $string['qbank'] = 'Question Bank';
 $string['qbank_desc'] = 'Create and organize quiz questions';
 $string['badges'] = 'Badges';

--- a/templates/teacherdash.mustache
+++ b/templates/teacherdash.mustache
@@ -44,6 +44,19 @@
                         {{/dashlinks}}
                     </div>
                     {{/hasquestionpermission}}
+                    {{#hascontentbankpermission}}
+                    <div class="dashtitle">
+                        <h3><i class="fa fa-paint-brush dashicon"></i>{{{cbanktitle}}}</h3>
+                        <p>{{{cbankdesc}}}</p>
+                    </div>
+                    <div class="list-group">
+                        {{#dashlinks}}
+                        {{#hascbanklinks}}
+                            <a href="{{{url}}}" class="list-group-item">{{{title}}}</a>
+                        {{/hascbanklinks}}
+                        {{/dashlinks}}
+                    </div>
+                    {{/hascontentbankpermission}} 
                     {{#hasbadgepermission}}
                     <div class="dashtitle">
                         <h3><i class="fa fa-trophy dashicon"></i>{{{badgestitle}}}</h3>


### PR DESCRIPTION
Moodle 3.9 added the content bank for managing H5P content.  In fordson, it's only available via the Boost menu.
It would be helpful to teachers if it was also available via the teacher dashboard (allowing us to hide the boost menu.

Screenshot attached
<img width="1554" alt="add content bank" src="https://user-images.githubusercontent.com/1093550/90087114-ff7b9000-dce9-11ea-852c-fc0e48bcb3d5.png">
