### PR TITLE
Update Easy Enrol button to fix capability

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -1149,7 +1149,7 @@ class core_renderer extends \theme_boost\output\core_renderer {
         $course = $this->page->course;
         $context = context_course::instance($course->id);
         $showincourseonly = isset($COURSE->id) && $COURSE->id > 1 && $PAGE->theme->settings->coursemanagementtoggle && isloggedin() && !isguestuser();
-        $haspermission = has_capability('enrol/category:config', $context) && $PAGE->theme->settings->coursemanagementtoggle && isset($COURSE->id) && $COURSE->id > 1;
+        $haspermission = has_capability('enrol/easy:config', $context) && $PAGE->theme->settings->coursemanagementtoggle && isset($COURSE->id) && $COURSE->id > 1;
         $togglebutton = '';
         $togglebuttonstudent = '';
         $hasteacherdash = '';


### PR DESCRIPTION
The "enrol/category:config" is not necessary to use easy enrol integration and if in the Moodle, for any reason, we remove mentioned capability from users they will not be able to see the "Key" button on top of course top bar. Instead, if we change it to "enrol/easy:config" it will be work fine because it is a required capability to grant to any user who is eligible to manage easy enrol codes.