### PR TITLE
Footer stucking to the viewport fix and MultiSlide feature for Fordson

### DIFF
--- a/classes/output/core_renderer.php
+++ b/classes/output/core_renderer.php
@@ -1120,28 +1120,48 @@ class core_renderer extends \theme_boost\output\core_renderer {
         global $PAGE;
         $theme = theme_config::load('fordson');
         $slideshowon = $PAGE->theme->settings->showslideshow == 1;
-        $hasslide1 = (empty($theme->setting_file_url('slide1image', 'slide1image'))) ? false : $theme->setting_file_url('slide1image', 'slide1image');
-        $slide1 = (empty($PAGE->theme->settings->slide1title)) ? false : $PAGE->theme->settings->slide1title;
-        $slide1content = (empty($PAGE->theme->settings->slide1content)) ? false : format_text($PAGE->theme->settings->slide1content);
-        $showtext1 = (empty($PAGE->theme->settings->slide1title)) ? false : format_text($PAGE->theme->settings->slide1title);
-        $hasslide2 = (empty($theme->setting_file_url('slide2image', 'slide2image'))) ? false : $theme->setting_file_url('slide2image', 'slide2image');
-        $slide2 = (empty($PAGE->theme->settings->slide2title)) ? false : $PAGE->theme->settings->slide2title;
-        $slide2content = (empty($PAGE->theme->settings->slide2content)) ? false : format_text($PAGE->theme->settings->slide2content);
-        $showtext2 = (empty($PAGE->theme->settings->slide2title)) ? false : format_text($PAGE->theme->settings->slide2title);
-        $hasslide3 = (empty($theme->setting_file_url('slide3image', 'slide3image'))) ? false : $theme->setting_file_url('slide3image', 'slide3image');
-        $slide3 = (empty($PAGE->theme->settings->slide3title)) ? false : $PAGE->theme->settings->slide3title;
-        $slide3content = (empty($PAGE->theme->settings->slide3content)) ? false : format_text($PAGE->theme->settings->slide3content);
-        $showtext3 = (empty($PAGE->theme->settings->slide3title)) ? false : format_text($PAGE->theme->settings->slide3title);
-        $fp_slideshow = ['hasfpslideshow' => $slideshowon, 'hasslide1' => $hasslide1 ? true : false, 'hasslide2' => $hasslide2 ? true : false, 'hasslide3' => $hasslide3 ? true : false, 'showtext1' => $showtext1 ? true : false, 'showtext2' => $showtext2 ? true : false, 'showtext3' => $showtext3 ? true : false, 'slide1' => array(
-            'slidetitle' => $slide1,
-            'slidecontent' => $slide1content
-        ) , 'slide2' => array(
-            'slidetitle' => $slide2,
-            'slidecontent' => $slide2content
-        ) , 'slide3' => array(
-            'slidetitle' => $slide3,
-            'slidecontent' => $slide3content
-        ) , ];
+        
+        // Multi-slide renderer for slideshow
+        // Loading current settings, if none previously set - then use 3 as standard value
+
+        $currentSlidesCount = (empty($PAGE->theme->settings->slideshowpages_count))?3:$PAGE->theme->settings->slideshowpages_count;
+
+        $fp_slideshow = ['hasfpslideshow' => $slideshowon]; // we shall only init this array
+        $slidesArray = []; // then we'll init an empty array which will be populated with slides
+
+        for ($slideIndex = 1; $slideIndex <= $currentSlidesCount; $slideIndex++) {
+
+            // grabbing current settings for this index
+            $title = $PAGE->theme->settings->{'slide'.$slideIndex.'title'};
+            $description = $PAGE->theme->settings->{'slide'.$slideIndex.'content'};
+            $imageUrl = $theme->setting_file_url('slide'.$slideIndex.'image', 'slide'.$slideIndex.'image');
+            $url = $PAGE->theme->settings->{'slide'.$slideIndex.'url'};
+            $boolNewTab = $PAGE->theme->settings->{'slide'.$slideIndex.'url_newtab'};
+            
+            // preparing properties
+            $slideTitle = (empty($title))?false:$title;
+            $slideImage = (empty($imageUrl))?false:$imageUrl;
+            $slideUrl = (empty($url))?false:$url;
+            $slideUrlNewTab = (empty($boolNewTab))?false:$boolNewTab; //probably an overkill but whatever
+            $slideContent = (empty($description))?false:$description;
+            $slideEnabled = empty($slideImage);
+            
+            $isFirst = ($slideIndex == 1)?true:false;
+
+            $slidesArray[] = array(
+                'idx' => $slideIndex - 1,
+                'first' => $isFirst,
+                'enabled' => $slideEnabled,
+                'slideurl' => $slideUrl,
+                'innewtab' => $slideUrlNewTab,
+                'slidetitle' => $slideTitle,
+                'slideimage' => $slideImage,
+                'slidecontent' => $slideContent
+            );
+        }
+
+        $fp_slideshow['slide'] = $slidesArray; // lastly we will add our slides array to the common structure
+
         return $this->render_from_template('theme_fordson/slideshow', $fp_slideshow);
     }
     public function teacherdashmenu() {

--- a/lang/en/theme_fordson.php
+++ b/lang/en/theme_fordson.php
@@ -146,6 +146,19 @@ $string['slideshowpages_desc'] = 'Determine what main pages the slideshow should
 $string['slideshowpages0'] = 'Show on custom login page only';
 $string['slideshowpages1'] = 'Show on Site Home and Dashboard only';
 $string['slideshowpages2'] = 'Show everywhere';
+$string['showtounauthorized'] = 'Slideshow is visible to unauthorized users';
+$string['showtounauthorized_desc'] = 'If this option is checked, slideshow will be visible to anyone, including unathorized users';
+
+// Slide manager
+$string['slideinfo'] = 'Slide ';
+$string['slideurl'] = 'URL';
+$string['slideurl_desc'] = 'You can specify an URL that will be opened upon clicking on this slide. <br><br><i>NOTICE: you can enter location of site sub-pages like "course/view.php?id=123". You must enter full page URL like "https://google.com/mail" otherwise.</i>';
+$string['slideurl_newtab'] = 'Open in new tab';
+$string['slideurl_newtab_desc'] = 'Set whether to open said URL in current or in new tab';
+$string['slideinfodesc'] = 'Slide details';
+$string['slideshowpages_page'] = 'Slideshow: Slide ';
+$string['slideshowpages_count'] = 'Slides count';
+$string['slideshowpages_count_desc'] = 'Set desired count of slides then save your changes. Upon next visit of this page you will see more or less tabs to fill';
 
 // Footer
 $string['footerheading'] = 'Footer';

--- a/layout/frontpage.php
+++ b/layout/frontpage.php
@@ -54,7 +54,14 @@ $blockshtmlb = $OUTPUT->blocks('fp-b');
 $blockshtmlc = $OUTPUT->blocks('fp-c');
 $hasfpblockregion = (isset($PAGE->theme->settings->blockdisplay) && ($PAGE->theme->settings->blockdisplay == 1)) !== false;
 
-$hasslideshowpages = (isset($PAGE->theme->settings->slideshowpages) && ($PAGE->theme->settings->slideshowpages == 1 || $PAGE->theme->settings->slideshowpages == 2)) !== false;
+$slideshowpagesenabled = (isset($PAGE->theme->settings->slideshowpages) && ($PAGE->theme->settings->slideshowpages == 1 || $PAGE->theme->settings->slideshowpages == 2)) !== false;
+$showtounauthorized = (isset($PAGE->theme->settings->showtounauthorized) && ($PAGE->theme->settings->showtounauthorized == 1 )) !== false;
+
+if (isloggedin()) {
+    $hasslideshowpages = $slideshowpagesenabled;
+} else {
+    $hasslideshowpages = ($slideshowpagesenabled && $showtounauthorized) !== false;
+}
 
 $regionmainsettingsmenu = $OUTPUT->region_main_settings_menu();
 $templatecontext = [

--- a/lib/filesettings_lib.php
+++ b/lib/filesettings_lib.php
@@ -43,53 +43,17 @@ function theme_fordson_pluginfile($course, $cm, $context, $filearea, $args, $for
     if (empty($theme)) {
         $theme = theme_config::load('fordson');
     }
+
+    // required by multi-slide feature
     if ($context->contextlevel == CONTEXT_SYSTEM && ($filearea === '')) {
         $theme = theme_config::load('fordson');
         return $theme->setting_file_serve($filearea, $args, $forcedownload, $options);
-    } else if ($filearea === 'headerlogo') {
-        return $theme->setting_file_serve('headerlogo', $args, $forcedownload, $options);
-    } else if ($filearea === 'favicon') {
-        return $theme->setting_file_serve('favicon', $args, $forcedownload, $options);
-    } else if ($filearea === 'feature1image') {
-        return $theme->setting_file_serve('feature1image', $args, $forcedownload, $options);
-    } else if ($filearea === 'feature2image') {
-        return $theme->setting_file_serve('feature2image', $args, $forcedownload, $options);
-    } else if ($filearea === 'feature3image') {
-        return $theme->setting_file_serve('feature3image', $args, $forcedownload, $options);
-    } else if ($filearea === 'headerdefaultimage') {
-        return $theme->setting_file_serve('headerdefaultimage', $args, $forcedownload, $options);
-    } else if ($filearea === 'backgroundimage') {
-        return $theme->setting_file_serve('backgroundimage', $args, $forcedownload, $options);
-    } else if ($filearea === 'loginimage') {
-        return $theme->setting_file_serve('loginimage', $args, $forcedownload, $options);
-    } else if ($filearea === 'logintopimage') {
-        return $theme->setting_file_serve('logintopimage', $args, $forcedownload, $options);
-    } else if ($filearea === 'marketing1image') {
-        return $theme->setting_file_serve('marketing1image', $args, $forcedownload, $options);
-    } else if ($filearea === 'marketing2image') {
-        return $theme->setting_file_serve('marketing2image', $args, $forcedownload, $options);
-    } else if ($filearea === 'marketing3image') {
-        return $theme->setting_file_serve('marketing3image', $args, $forcedownload, $options);
-    } else if ($filearea === 'marketing4image') {
-        return $theme->setting_file_serve('marketing4image', $args, $forcedownload, $options);
-    } else if ($filearea === 'marketing5image') {
-        return $theme->setting_file_serve('marketing5image', $args, $forcedownload, $options);
-    } else if ($filearea === 'marketing6image') {
-        return $theme->setting_file_serve('marketing6image', $args, $forcedownload, $options);
-    } else if ($filearea === 'marketing7image') {
-        return $theme->setting_file_serve('marketing7image', $args, $forcedownload, $options);
-    } else if ($filearea === 'marketing8image') {
-        return $theme->setting_file_serve('marketing8image', $args, $forcedownload, $options);
-    } else if ($filearea === 'marketing9image') {
-        return $theme->setting_file_serve('marketing9image', $args, $forcedownload, $options);
-    } else if ($filearea === 'slide1image') {
-        return $theme->setting_file_serve('slide1image', $args, $forcedownload, $options);
-    } else if ($filearea === 'slide2image') {
-        return $theme->setting_file_serve('slide2image', $args, $forcedownload, $options);
-    } else if ($filearea === 'slide3image') {
-        return $theme->setting_file_serve('slide3image', $args, $forcedownload, $options);
     } else {
-        send_file_not_found();
+        try {
+            return $theme->setting_file_serve($filearea, $args, $forcedownload, $options);
+        } catch (Exception $e){
+            send_file_not_found();
+        }
     }
 }
 

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -176,6 +176,17 @@ div#fordsonlogin {
     z-index: 0;
 }
 
+/* 
+For some reason footer became stuck to viewport height.
+that property comes from Boost theme, possibly its updated property of #page-wrapper
+causes it to float around the bottom of the viewport. There's not a single declaration of #page-wrapper
+height through all of Fordson CSS. Adding this as a quick workaround.
+*/
+
+#page-wrapper {
+    height: auto;
+}
+
 #page-my-index {
     background-color: $body-bg;
 }

--- a/settings/slideshow_settings.php
+++ b/settings/slideshow_settings.php
@@ -51,6 +51,15 @@ $setting = new admin_setting_configselect($name, $title, $description, $default,
 $setting->set_updatedcallback('theme_reset_all_caches');
 $page->add($setting);
 
+// Whether to show slideshow to unauthorized users
+$name = 'theme_fordson/showtounauthorized';
+$title = get_string('showtounauthorized', 'theme_fordson');
+$description = get_string('showtounauthorized_desc', 'theme_fordson');
+$default = 1;
+$setting = new admin_setting_configcheckbox($name, $title, $description, $default);
+$setting->set_updatedcallback('theme_reset_all_caches');
+$page->add($setting);
+
 // Header size setting.
 $name = 'theme_fordson/slideshowheight';
 $title = get_string('slideshowheight', 'theme_fordson');
@@ -118,103 +127,82 @@ $setting = new admin_setting_configselect($name, $title, $description, $default,
 $setting->set_updatedcallback('theme_reset_all_caches');
 $page->add($setting);
 
-// This is the descriptor for slide
-$name = 'theme_fordson/slide1info';
-$heading = get_string('slide1info', 'theme_fordson');
-$information = get_string('slide1infodesc', 'theme_fordson');
-$setting = new admin_setting_heading($name, $heading, $information);
-$page->add($setting);
+// Multi-slide property pages for slideshow
+// Loading current settings
+global $PAGE;
+$currentSlidesCount = (empty($PAGE->theme->settings->slideshowpages_count))?3:$PAGE->theme->settings->slideshowpages_count;
 
-// Slide title
-$name = 'theme_fordson/slide1title';
-$title = get_string('slidetitle', 'theme_fordson');
-$description = get_string('slidetitle_desc', 'theme_fordson');
-$default = '';
-$setting = new admin_setting_configtext($name, $title, $description, $default);
-$setting->set_updatedcallback('theme_reset_all_caches');
-$page->add($setting);
+// Count of slides
+// we'll better use this than simple textbox
+use theme_foundation\admin_setting_configinteger;
 
-//Slide Description
-$name = 'theme_fordson/slide1content';
-$title = get_string('slidecontent', 'theme_fordson');
-$description = get_string('slidecontent_desc', 'theme_fordson');
-$default = '';
-$setting = new admin_setting_confightmleditor($name, $title, $description, $default);
-$setting->set_updatedcallback('theme_reset_all_caches');
-$page->add($setting);
-
-// logo image.
-$name = 'theme_fordson/slide1image';
-$title = get_string('slideimage', 'theme_fordson');
-$description = get_string('slideimage_desc', 'theme_fordson');
-$setting = new admin_setting_configstoredfile($name, $title, $description, 'slide1image');
-$setting->set_updatedcallback('theme_reset_all_caches');
-$page->add($setting);
-
-// This is the descriptor for slide
-$name = 'theme_fordson/slide2info';
-$heading = get_string('slide2info', 'theme_fordson');
-$information = get_string('slide2infodesc', 'theme_fordson');
-$setting = new admin_setting_heading($name, $heading, $information);
-$page->add($setting);
-
-// Slide title
-$name = 'theme_fordson/slide2title';
-$title = get_string('slidetitle', 'theme_fordson');
-$description = get_string('slidetitle_desc', 'theme_fordson');
-$default = '';
-$setting = new admin_setting_configtext($name, $title, $description, $default);
-$setting->set_updatedcallback('theme_reset_all_caches');
-$page->add($setting);
-
-//Slide Description
-$name = 'theme_fordson/slide2content';
-$title = get_string('slidecontent', 'theme_fordson');
-$description = get_string('slidecontent_desc', 'theme_fordson');
-$default = '';
-$setting = new admin_setting_confightmleditor($name, $title, $description, $default);
-$setting->set_updatedcallback('theme_reset_all_caches');
-$page->add($setting);
-
-// logo image.
-$name = 'theme_fordson/slide2image';
-$title = get_string('slideimage', 'theme_fordson');
-$description = get_string('slideimage_desc', 'theme_fordson');
-$setting = new admin_setting_configstoredfile($name, $title, $description, 'slide2image');
-$setting->set_updatedcallback('theme_reset_all_caches');
-$page->add($setting);
-
-// This is the descriptor for slide
-$name = 'theme_fordson/slide3info';
-$heading = get_string('slide3info', 'theme_fordson');
-$information = get_string('slide3infodesc', 'theme_fordson');
-$setting = new admin_setting_heading($name, $heading, $information);
-$page->add($setting);
-// Slide title
-$name = 'theme_fordson/slide3title';
-$title = get_string('slidetitle', 'theme_fordson');
-$description = get_string('slidetitle_desc', 'theme_fordson');
-$default = '';
-$setting = new admin_setting_configtext($name, $title, $description, $default);
-$setting->set_updatedcallback('theme_reset_all_caches');
-$page->add($setting);
-
-//Slide Description
-$name = 'theme_fordson/slide3content';
-$title = get_string('slidecontent', 'theme_fordson');
-$description = get_string('slidecontent_desc', 'theme_fordson');
-$default = '';
-$setting = new admin_setting_confightmleditor($name, $title, $description, $default);
-$setting->set_updatedcallback('theme_reset_all_caches');
-$page->add($setting);
-
-// logo image.
-$name = 'theme_fordson/slide3image';
-$title = get_string('slideimage', 'theme_fordson');
-$description = get_string('slideimage_desc', 'theme_fordson');
-$setting = new admin_setting_configstoredfile($name, $title, $description, 'slide3image');
-$setting->set_updatedcallback('theme_reset_all_caches');
+$name = 'theme_fordson/slideshowpages_count';
+$title = get_string('slideshowpages_count', 'theme_fordson');
+$description = get_string('slideshowpages_count_desc', 'theme_fordson');
+$default = 3;
+$lower = 1;
+$upper = 30;
+$setting = new admin_setting_configinteger($name,$title,$description,$default, $lower, $upper);
 $page->add($setting);
 
 // Must add the page after definiting all the settings!
 $settings->add($page);
+
+// After that is done let's create tabs with per-slide options
+
+for ($slideIndex = 1; $slideIndex <= $currentSlidesCount; $slideIndex++) {
+    $slideSettingsPage = new admin_settingpage('theme_fordson_slide' . $slideIndex . 'settings_page', get_string('slideshowpages_page','theme_fordson') . $slideIndex);
+    
+    // This is the descriptor for slide
+    $name = 'theme_fordson/slide'.$slideIndex.'info';
+    $heading = get_string('slideinfo', 'theme_fordson') . $slideIndex;
+    $information = get_string('slideinfodesc', 'theme_fordson');
+    $slideSettingsPageElement = new admin_setting_heading($name, $heading, $information);
+    $slideSettingsPage->add($slideSettingsPageElement);
+
+    // Slide title
+    $name = 'theme_fordson/slide'.$slideIndex.'title';
+    $title = get_string('slidetitle', 'theme_fordson');
+    $description = get_string('slidetitle_desc', 'theme_fordson');
+    $default = '';
+    $slideSettingsPageElement = new admin_setting_configtext($name, $title, $description, $default);
+    $slideSettingsPageElement->set_updatedcallback('theme_reset_all_caches');
+    $slideSettingsPage->add($slideSettingsPageElement);
+
+    // Slide click-to-visit URL
+    $name = 'theme_fordson/slide'.$slideIndex.'url';
+    $title = get_string('slideurl', 'theme_fordson');
+    $description = get_string('slideurl_desc', 'theme_fordson');
+    $default = '';
+    $slideSettingsPageElement = new admin_setting_configtext($name, $title, $description, $default);
+    $slideSettingsPageElement->set_updatedcallback('theme_reset_all_caches');
+    $slideSettingsPage->add($slideSettingsPageElement);
+
+    // Slide URL option - open in new tab
+    $name = 'theme_fordson/slide'.$slideIndex.'url_newtab';
+    $title = get_string('slideurl_newtab', 'theme_fordson');
+    $description = get_string('slideurl_newtab_desc', 'theme_fordson');
+    $default = false;
+    $slideSettingsPageElement = new admin_setting_configcheckbox($name,$title,$description,$default);
+    $slideSettingsPageElement->set_updatedcallback('theme_reset_all_caches');
+    $slideSettingsPage->add($slideSettingsPageElement);
+
+    //Slide Description
+    $name = 'theme_fordson/slide'.$slideIndex.'content';
+    $title = get_string('slidecontent', 'theme_fordson');
+    $description = get_string('slidecontent_desc', 'theme_fordson');
+    $default = '';
+    $slideSettingsPageElement = new admin_setting_confightmleditor($name, $title, $description, $default);
+    $slideSettingsPageElement->set_updatedcallback('theme_reset_all_caches');
+    $slideSettingsPage->add($slideSettingsPageElement);
+
+    // logo image.
+    $name = 'theme_fordson/slide'.$slideIndex.'image';
+    $title = get_string('slideimage', 'theme_fordson');
+    $description = get_string('slideimage_desc', 'theme_fordson');
+    $slideSettingsPageElement = new admin_setting_configstoredfile($name, $title, $description, 'slide'.$slideIndex.'image');
+    $slideSettingsPageElement->set_updatedcallback('theme_reset_all_caches');
+    $slideSettingsPage->add($slideSettingsPageElement);
+
+    $settings->add($slideSettingsPage);
+}

--- a/templates/slideshow.mustache
+++ b/templates/slideshow.mustache
@@ -3,54 +3,36 @@
 <div id="fordsoncarousel" class="carousel slide carousel-fade d-none d-sm-block" data-ride="carousel">
 
   <ol class="carousel-indicators">
-    {{#hasslide1}}<li data-target="#fordsoncarousel" data-slide-to="0" class="active"></li>{{/hasslide1}}
-    {{#hasslide2}}<li data-target="#fordsoncarousel" data-slide-to="1"></li>{{/hasslide2}}
-    {{#hasslide3}}<li data-target="#fordsoncarousel" data-slide-to="2"></li>{{/hasslide3}}
+    {{#slide}}
+    <li data-target="#fordsoncarousel" data-slide-to="{{idx}}"></li>
+    {{/slide}}
   </ol>
 
-<div class="carousel-inner" role="listbox">
+  <div class="carousel-inner" role="listbox">
+    {{#slide}}
+    <div class="carousel-item{{#first}} active{{/first}}">
+      <!-- We will use 'slide1image' class on all slides, then substitute the image via inline style -->
+      <!-- A possible better solution is to define a new class in theme css -->
+      <div class="slide1image" style="background-image: url({{slideimage}});{{#slideurl}} cursor: pointer;{{/slideurl}}" {{#slideurl}}onclick="{{#innewtab}}window.open('{{{slideurl}}}', '_blank');{{/innewtab}}{{^innewtab}}location.href='{{{slideurl}}}';{{/innewtab}}"{{/slideurl}}></div>
+      {{#slidetitle}}
+      <div class="carousel-caption d-none d-sm-block">
+        <h3>{{{slidetitle}}}</h3>
+        <p>{{{slidecontent}}}</p>
+      </div>
+      {{/slidetitle}}
+    </div>
+    {{/slide}}
+  </div>
 
-    {{#hasslide1}}
-    <div class="carousel-item active">
-      <div class="slide1image"></div>
-      {{#showtext1}}
-      {{#slide1}}
-      <div class="carousel-caption d-none d-sm-block">
-        <h3>{{{slidetitle}}}</h3>
-        <p>{{{slidecontent}}}</p>
-      </div>
-      {{/slide1}}
-      {{/showtext1}}
-    </div>
-    {{/hasslide1}}
-    
-    {{#hasslide2}}
-    <div class="carousel-item">
-      <div class="slide2image"></div>
-      {{#showtext2}}
-      {{#slide2}}
-      <div class="carousel-caption d-none d-sm-block">
-        <h3>{{{slidetitle}}}</h3>
-        <p>{{{slidecontent}}}</p>
-      </div>
-      {{/slide2}}
-      {{/showtext2}}
-    </div>
-    {{/hasslide2}}
 
-    {{#hasslide3}}
-    <div class="carousel-item">
-      <div class="slide3image"></div>
-      {{#showtext3}}
-      {{#slide3}}
-      <div class="carousel-caption d-none d-sm-block">
-        <h3>{{{slidetitle}}}</h3>
-        <p>{{{slidecontent}}}</p>
-      </div>
-      {{/slide3}}
-      {{/showtext3}}
-    </div>
-    {{/hasslide3}}
+  <a class="left carousel-control" href="#fordsoncarousel" role="button" data-slide="prev">
+    <i class="fa fa-chevron-left" aria-hidden="true"></i>
+    <span class="sr-only">Previous</span>
+  </a>
+  <a class="right carousel-control" href="#fordsoncarousel" role="button" data-slide="next">
+    <i class="fa fa-chevron-right" aria-hidden="true"></i>
+    <span class="sr-only">Next</span>
+  </a>
 
 </div>
     <a class="left carousel-control" href="#fordsoncarousel" role="button" data-slide="prev">

--- a/version.php
+++ b/version.php
@@ -33,4 +33,6 @@ $plugin->requires  = 2021051100;
 $plugin->component = 'theme_fordson';
 $plugin->dependencies = array(
     'theme_boost'  => 2021051700,
+    'theme_foundation' => 2021051804
+    // theme_foundation required as we use admin_setting_configinteger in our slideshow_settings.php
 );


### PR DESCRIPTION
Greetings!
Here's a brief overview of changes:

**Fixes:**
 - #page-wrapper CSS class now has presence in Fordson SCSS. That fixes invalid footer behaviour (sticking mid-page on long pages)

**Features:**
 - User can now adjust quantity of slides in the main slideshow via Moodle Admin Settings pages for the Fordson theme
 - User can now hide slideshow from unregistered users
 - Slide image can now be supplied with a hyperlink to some internal or external web page.
 - Minor code optimisation to make it more scalable.